### PR TITLE
Added toasts and a now-playing block to the HTML

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,40 +1,43 @@
-
-html  {
-    background-image: url('../images/hero2.jpeg');
-    background-size: cover;
-    background-position: center center;
-    font-family: 'Roboto',sans-serif;
-
-    
-    
-    
+html {
+  background-image: url('../images/hero2.jpeg');
+  background-size: cover;
+  background-position: center center;
+  font-family: 'Roboto', sans-serif;
 }
 
 .box {
-    opacity: .9;
-    margin-top: 20%;
-
+  opacity: 0.9;
+  margin-top: 20%;
 }
 
-.hero{
-    position: relative;
-    overflow: hidden;
+.hero {
+  position: relative;
+  overflow: hidden;
 }
 .has-background {
-    position: absolute;
-    object-fit: cover;
-    object-position: center center;
-    width: 100%;
-    height: 100%;
+  position: absolute;
+  object-fit: cover;
+  object-position: center center;
+  width: 100%;
+  height: 100%;
 }
 
 .button {
-    padding-right: 10%;
-     margin-left: 10%; 
-     margin-right: 10%;
-     padding-left: 7%;
-     
+  padding-right: 10%;
+  margin-left: 10%;
+  margin-right: 10%;
+  padding-left: 7%;
 }
 
-    
-  
+.now-playing {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.now-playing figure {
+  width: 24rem;
+  border: 1px solid black;
+}
+.now-playing img {
+  opacity: 1;
+}

--- a/assets/js/lib/pkce-handler.js
+++ b/assets/js/lib/pkce-handler.js
@@ -60,9 +60,7 @@ class PkceHandler {
           );
         }
         // synthetic events are synchronous
-        setTimeout(() => {
-          document.body.dispatchEvent(this.authorizedEvent);
-        }, 10);
+        setTimeout(() => document.body.dispatchEvent(this.authorizedEvent), 10);
       }
     }
   }

--- a/assets/js/lib/pkce-handler.js
+++ b/assets/js/lib/pkce-handler.js
@@ -178,7 +178,7 @@ class PkceHandler {
     body.append('code_verifier', providerState.codeVerifier);
     const req = {method: 'POST', body};
     const response = await fetch(c.tokenUrl, req);
-    if (!response.ok) throw new Error(response.statusText);
+    if (!response.ok) throw new Error(response);
     const data = await response.json();
     this._applyToken(data);
     setTimeout(() => {
@@ -196,7 +196,7 @@ class PkceHandler {
     body.append('client_id', this.providerConfig.clientId);
     const req = {method: 'POST', body};
     const response = await fetch(this.providerConfig.tokenUrl, req);
-    if (!response.ok) throw new Error(response.statusText);
+    if (!response.ok) throw new Error(response);
     const data = await response.json();
     this._applyToken(data);
   }

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -84,7 +84,7 @@ async function streamCurrentTrackInfo(doTimeoutPoll = false) {
     lastTrack = currentTrack;
     nextPoll = currentTrack.timeRemaining;
   }
-  if (doTimeoutPoll) {
+  if (doTimeoutPoll && nextPoll) {
     setTimeout(() => {
       streamCurrentTrackInfo(true);
     }, nextPoll);
@@ -111,6 +111,7 @@ function spotifyAuthRequest() {
   try {
     spotifyClient.requestCode.bind(spotifyClient)();
   } catch (error) {
+    // proper error handling
     toast(`Error: "${error}" when attemping to connect to Spotify.`, 'is-danger');
   }
 }

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -1,103 +1,174 @@
 /* global spotifyClient */
 import {PkceHandler} from './lib/pkce-handler.js';
-import {DateTime, Duration} from './lib/luxon.js';
-
+import * as bulmaToast from 'https://cdn.jsdelivr.net/npm/bulma-toast@2.0.1/dist/bulma-toast.esm.js';
+// custom events
 function trackChangeEvent(trackInfo) {
   setTimeout(document.body.dispatchEvent(new CustomEvent('trackChange', {bubbles: true, detail: trackInfo})), 10);
 }
+function nowPlayingException(trackInfo) {
+  setTimeout(
+    document.body.dispatchEvent(new CustomEvent('nowPlayingException', {bubbles: true, detail: trackInfo})),
+    10
+  );
+}
+// bulmaToast wrapper
+const toast = (message, type, position = 'top-center', duration = 6000) =>
+  bulmaToast.toast({
+    message,
+    type,
+    duration,
+    position,
+    dissmissible: true,
+    animate: {in: 'fadeIn', out: 'fadeOut'},
+  });
 
+// HTML element hooks
+const spotifyBtn = document.querySelector('#access-spotify');
+const spotifyBtnLabel = document.querySelector('#access-spotify .button-title');
+const nowPlayingDiv = document.querySelector('.now-playing');
+
+// module globals
+const NOW_PLAYING_EXCEPTIONS = Object.freeze({
+  ad: 'Advertisement(s) are currently playing.',
+  notPlaying: 'Nothing is currently playing on Spotify.',
+  sameTrack: "The current track hasn't changed from the last request.",
+});
+
+let lastTrack;
+
+// These two functions combined generate synthetic events whenever what's currently playing in Spotify changes
 async function getCurrentTrackInfo() {
   let response;
   try {
     response = await spotifyClient.fetch('https://api.spotify.com/v1/me/player/currently-playing');
   } catch (error) {
-    console.error(error);
+    toast(`Error: "${error}" when attemping to ask Spotify what's currently playing.`, 'is-danger');
   }
   if (response.ok) {
     if (response.status === 204) {
-      return {error: 'not_playing'};
+      return {error: 'notPlaying'};
     } else {
       const data = await response.json();
       if (data.currently_playing_type === 'ad') return {error: 'ad'};
-      // 150ms offset to timeRemaining as a kludge
+      // 150ms offset to timeRemaining as a kludge that appears to work (it isn't poking Spotify right at the end of the track anymore)
       const timeRemaining = data.progress_ms ? data.item.duration_ms - data.progress_ms + 150 : data.item.duration_ms;
       const artists = [];
       for (const artist of data.item.artists) artists.push(artist.name);
-      return {artists, track: data.item.name, album: data.item.album.name, timeRemaining};
+      const out = {
+        artists,
+        track: data.item.name,
+        album: data.item.album.name,
+        albumArt: data.item.album.images[0].url,
+        timeRemaining,
+      };
+      if (!data.is_playing) out.error = 'notPlaying'; // playback is paused or stopped
+      return out;
     }
   }
 }
-
-async function currentTrackStream() {
+async function streamCurrentTrackInfo(doTimeoutPoll = false) {
   const currentTrack = await getCurrentTrackInfo();
-  trackChangeEvent(currentTrack);
+  const sameTrack =
+    lastTrack &&
+    lastTrack.track === currentTrack.track &&
+    lastTrack.album === currentTrack.album &&
+    lastTrack.artists.toString() === currentTrack.artists.toString();
+
+  if (sameTrack) currentTrack.error = 'sameTrack';
+  else doTimeoutPoll = true;
+  let nextPoll = null;
   if (Object.keys(currentTrack).includes('error')) {
-    let nextPoll = null;
-    if (currentTrack.error === 'ad') nextPoll = 1000 * 30;
+    nowPlayingException(currentTrack);
+    if (['ad', 'sameTrack'].includes(currentTrack.error)) nextPoll = 1000 * 30;
     else nextPoll = 1000 * 60;
-    console.debug(`Next poll happens in ${Duration.fromMillis(nextPoll).as('seconds')}s`);
-    setTimeout(() => {
-      console.debug(`Track stream poll at ${DateTime.local().toLocaleString(DateTime.DATETIME_SHORT)}`);
-      currentTrackStream();
-    }, nextPoll);
   } else {
-    console.debug(`Next poll happens in ${Duration.fromMillis(currentTrack.timeRemaining).as('seconds')}s`);
+    trackChangeEvent(currentTrack);
+    lastTrack = currentTrack;
+    nextPoll = currentTrack.timeRemaining;
+  }
+  if (doTimeoutPoll) {
     setTimeout(() => {
-      console.debug(`Track stream poll at ${DateTime.local().toLocaleString(DateTime.DATETIME_SHORT)}`);
-      currentTrackStream();
-    }, currentTrack.timeRemaining);
+      streamCurrentTrackInfo(true);
+    }, nextPoll);
   }
 }
-
-document.body.addEventListener('authorized', (event) => {
-  console.debug(`provider "${event.detail.provider}" authorized`);
-  currentTrackStream();
-});
-
-document.body.addEventListener('trackChange', (event) => {
-  if (Object.keys(event.detail).includes('error')) {
-    console.log(`No current song: "${event.detail.error}"`);
-  } else {
-    let artistsAsString = '';
-    for (let i = 0; i < event.detail.artists.length; i++) {
-      if (i < event.detail.artists.length - 1) artistsAsString += `${event.detail.artists[i]}, `;
-      else artistsAsString += event.detail.artists[i];
-    }
-    console.log(`Currently playing: "${event.detail.track}" by ${artistsAsString} (from "${event.detail.album}")`);
-  }
-});
 
 // assigning to window to make it easier to test/debug, remember to change later.
 window.spotifyClient = new PkceHandler(
   {
     clientId: 'dd7f3da7892d4f0b993617370f503172',
-    redirectUrl: 'https://mayorgak.github.io/project-1/',
-    // redirectUrl: 'http://127.0.0.1:5500/index.html',
-    // redirectUrl: 'https://gminteer.github.io/proj1-test-space/',
+    // redirectUrl: 'https://mayorgak.github.io/project-1/',
+    redirectUrl: 'http://127.0.0.1:5500/index.html',
     authorizationUrl: 'https://accounts.spotify.com/authorize',
     tokenUrl: 'https://accounts.spotify.com/api/token',
     scope: 'user-read-playback-state',
   },
-  'spotifyTest'
+  'spotify'
 );
 spotifyClient.getCurrentTrackInfo = getCurrentTrackInfo;
-spotifyClient.currentTrackStream = currentTrackStream;
+spotifyClient.currentTrackStream = streamCurrentTrackInfo;
 
-document.querySelector('#access-spotify').addEventListener('click', spotifyClient.requestCode.bind(spotifyClient));
+// Event handling
+function spotifyAuthRequest() {
+  try {
+    spotifyClient.requestCode.bind(spotifyClient)();
+  } catch (error) {
+    toast(`Error: "${error}" when attemping to connect to Spotify.`, 'is-danger');
+  }
+}
+spotifyBtn.addEventListener('click', spotifyAuthRequest);
 
+document.body.addEventListener('authorized', (event) => {
+  toast(
+    'Spotify connected! Click the "Resync with Spotify" button to update if you change tracks manually in Spotify.',
+    'is-success'
+  );
+  streamCurrentTrackInfo(true);
+  // re-wire "connect to Spotify" button to be "re-sync with Spotify"
+  spotifyBtn.removeEventListener('click', spotifyAuthRequest);
+  spotifyBtn.addEventListener('click', () => streamCurrentTrackInfo(false));
+  spotifyBtnLabel.textContent = 'Resync with Spotify';
+});
+
+document.body.addEventListener('trackChange', (event) => {
+  let artistsAsString = '';
+  for (let i = 0; i < event.detail.artists.length; i++) {
+    if (i < event.detail.artists.length - 1) artistsAsString += `${event.detail.artists[i]}, `;
+    else artistsAsString += event.detail.artists[i];
+  }
+  nowPlayingDiv.querySelector('td.artist').textContent = artistsAsString;
+  nowPlayingDiv.querySelector('td.track').textContent = event.detail.track;
+  nowPlayingDiv.querySelector('td.album').textContent = event.detail.album;
+  nowPlayingDiv.querySelector('img').src = event.detail.albumArt;
+  if (nowPlayingDiv.classList.contains('is-hidden')) nowPlayingDiv.classList.remove('is-hidden');
+});
+
+document.body.addEventListener('nowPlayingException', (event) => {
+  if (event.detail.error !== 'sameTrack') {
+    toast(`${NOW_PLAYING_EXCEPTIONS[event.detail.error]} Please Stand By.`, 'is-warning');
+    if (!nowPlayingDiv.classList.contains('is-hidden')) nowPlayingDiv.classList.add('is-hidden');
+  }
+});
+
+// void main(void)
 const search = window.location.href.split('?')[1];
 if (search) {
-  const providerState = spotifyClient.providerName
-    ? JSON.parse(localStorage.getItem(spotifyClient.storageKey))[spotifyClient.providerName]
-    : JSON.parse(localStorage.getItem(spotifyClient.storageKey));
-  if (providerState.sentCodeReq) {
-    const searchParams = new URLSearchParams(search);
-    if (searchParams.has('error')) {
-      console.error(searchParams.get('error'));
-    } else if (searchParams.has('code')) {
-      const response = {};
-      for (const [key, value] of searchParams) response[key] = value;
-      spotifyClient.requestToken(response);
+  const dataStash = JSON.parse(localStorage.getItem(spotifyClient.storageKey));
+  if (dataStash) {
+    const providerState = spotifyClient.providerName ? dataStash[spotifyClient.providerName] : dataStash;
+    if (providerState.sentCodeReq) {
+      const searchParams = new URLSearchParams(search);
+      if (searchParams.has('error')) {
+        toast(`Error: "${searchParams.get('error')}" when attemping to connect to Spotify.`, 'is-danger');
+      } else if (searchParams.has('code')) {
+        const response = {};
+        for (const [key, value] of searchParams) response[key] = value;
+        try {
+          spotifyClient.requestToken(response);
+        } catch (error) {
+          toast(`Error: "${searchParams.get('error')}" when attemping to connect to Spotify.`, 'is-danger');
+        }
+      }
     }
   }
 }

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -22,9 +22,7 @@ const toast = (message, type, position = 'top-center', duration = 6000) =>
     animate: {in: 'fadeIn', out: 'fadeOut'},
   });
 
-// HTML element hooks
 const spotifyBtn = document.querySelector('#access-spotify');
-const spotifyBtnLabel = document.querySelector('#access-spotify .button-title');
 const nowPlayingDiv = document.querySelector('.now-playing');
 
 // module globals
@@ -127,7 +125,7 @@ document.body.addEventListener('authorized', (event) => {
   // re-wire "connect to Spotify" button to be "re-sync with Spotify"
   spotifyBtn.removeEventListener('click', spotifyAuthRequest);
   spotifyBtn.addEventListener('click', () => streamCurrentTrackInfo(false));
-  spotifyBtnLabel.textContent = 'Resync with Spotify';
+  spotifyBtn.querySelector('.button-title').textContent = 'Resync with Spotify';
 });
 
 document.body.addEventListener('trackChange', (event) => {

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -166,7 +166,7 @@ if (search) {
         try {
           spotifyClient.requestToken(response);
         } catch (error) {
-          toast(`Error: "${searchParams.get('error')}" when attemping to connect to Spotify.`, 'is-danger');
+          toast(`Error: "${error}" when attemping to connect to Spotify.`, 'is-danger');
         }
       }
     }

--- a/assets/js/spotify.js
+++ b/assets/js/spotify.js
@@ -97,8 +97,8 @@ async function streamCurrentTrackInfo(doTimeoutPoll = false) {
 window.spotifyClient = new PkceHandler(
   {
     clientId: 'dd7f3da7892d4f0b993617370f503172',
-    // redirectUrl: 'https://mayorgak.github.io/project-1/',
-    redirectUrl: 'http://127.0.0.1:5500/index.html',
+    redirectUrl: 'https://mayorgak.github.io/project-1/',
+    // redirectUrl: 'http://127.0.0.1:5500/index.html',
     authorizationUrl: 'https://accounts.spotify.com/authorize',
     tokenUrl: 'https://accounts.spotify.com/api/token',
     scope: 'user-read-playback-state',

--- a/index.html
+++ b/index.html
@@ -1,39 +1,62 @@
 <!DOCTYPE html>
-
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title> Lyric Look-up </title>
-        <meta name="description" content="">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;1,400&display=swap" rel="stylesheet">
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Lyric Look-up</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;1,400&display=swap" rel="stylesheet" />
     <!--Bulma Link-->
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.0/css/bulma-rtl.css">
-        <script src="https://kit.fontawesome.com/08ffba74b7.js" crossorigin="anonymous"></script>
-       <link rel="stylesheet" href="assets/css/styles.css">
-    </head>
-    <body>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.9.0/css/bulma-rtl.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.0.0/animate.min.css" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
     <!-- Hero -->
-    <section class="hero-head is-bold is-fullheight  has-text-centered has-text-center-mobile is-size-1-mobile">
-                <div class="hero-body">
-                    <div class="container has has-text-centered">
-                          <div class="column is-8 is-offset-2">
-                            <div class="box">
-                            <p class="title is-1 is-spaced has-text-grey-darker ">Lyric Look-up</p>
-                             <p class="subtitle is-4 is-italic has-text-grey-darker">"Sing along to your favorite song"</p>
-                         <div class="field is-grouped">
-                     </div>
+    <section class="hero-head is-bold is-fullheight has-text-centered has-text-center-mobile is-size-1-mobile">
+      <div class="hero-body">
+        <div class="container has has-text-centered">
+          <div class="column is-8 is-offset-2">
+            <div class="box">
+              <p class="title is-1 is-spaced has-text-grey-darker">Lyric Look-up</p>
+              <p class="subtitle is-4 is-italic has-text-grey-darker">"Sing along to your favorite song"</p>
+              <div class="field is-grouped">
                 <a class="button is-warning" id="access-spotify">
-                <span class="icon mx-1">
-                 <i class="fab fa-spotify"></i>
-                </span>
-                 <span class="button-title"> Connect to Spotify </span>
+                  <span class="icon mx-1">
+                    <i class="fab fa-spotify"></i>
+                  </span>
+                  <span class="button-title"> Connect to Spotify </span>
                 </a>
+              </div>
             </div>
+            <div class="box now-playing is-hidden">
+              <figure class="image">
+                <img />
+              </figure>
+              <table class="table is-fullwidth mx-3">
+                <tbody>
+                  <tr>
+                    <th class="has-text-right">Artist(s):</th>
+                    <td class="artist has-text-left"></td>
+                  </tr>
+                  <tr>
+                    <th class="has-text-right">Album:</th>
+                    <td class="album has-text-left"></td>
+                  </tr>
+                  <tr>
+                    <th class="has-text-right">Track:</th>
+                    <td class="track has-text-left"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
-    </div>
+      </div>
     </section>
-    </body>
+    <script src="https://kit.fontawesome.com/08ffba74b7.js" crossorigin="anonymous"></script>
     <script src="./assets/js/script.js" async defer></script>
-    <script src="assets/js/spotify.js" type="module"></script>
+    <script src="./assets/js/spotify.js" async defer type="module"></script>
+  </body>
 </html>


### PR DESCRIPTION
I went ahead and made a first-pass at integrating the Spotify client stuff into the app's UI. I feel a bit guilty touching index.html, but less so since I'm not [inflating my commit numbers](https://i.redd.it/9qladhjfvtq21.jpg) this time.

There's a couple of changes that aren't captured in the summary

- trackChange events only happen when the track has actually changed and changed into something worth trying to look up lyrics for. If Spotify starts playing ads or gets paused or something spotify.js  generates a nowPlayingException event now (instead of it being a trackChange event with an error property in event.details. trackChange events also have a URL for the album artwork attached to them (event.detail.albumArt)

- spotify.js re-wires the "Connect to Spotify" button into a "refresh what's currently playing on Spotify" button after it has an authorization token. I experimented a bit with trying to make that more automated, but I'm fairly convinced trying to do something fancier than a manual re-sync isn't really worth the effort.